### PR TITLE
Dates

### DIFF
--- a/components/activities/ActivitiesList.tsx
+++ b/components/activities/ActivitiesList.tsx
@@ -102,8 +102,8 @@ class AActivitiesList extends React.Component<Props, State> {
         // Unresolved, then in progress, then resolved.
 
         // Activities that need resolved should go first.
-        const aEnd = a.end_date.getTime();
-        const bEnd = b.end_date.getTime();
+        const aEnd = new Date(a.end_date).getTime();
+        const bEnd = new Date(b.end_date).getTime();
         const aCompleted = aEnd <= todayTime;
         const bCompleted = bEnd <= todayTime;
         const aResolved = a.resolution_text.length > 0;
@@ -156,7 +156,9 @@ class AActivitiesList extends React.Component<Props, State> {
 
   private renderActivityRow(activity: ActivityData, index: number): React.ReactNode {
     const selectedClass = activity.id === this.props.activeActivityId ? styles.selected : "";
-    const readyClass = activity.end_date.getTime() < new Date().getTime() ? styles.ready : "";
+    const localEndDate = new Date(activity.end_date);
+    let localEndDateTime = localEndDate.getTime() + localEndDate.getTimezoneOffset() * 60000;
+    const readyClass = new Date(activity.end_date).getTime() < new Date().getTime() ? styles.ready : "";
     return (
       <div
         className={`${styles.listRow} ${selectedClass} ${readyClass}`}
@@ -166,7 +168,7 @@ class AActivitiesList extends React.Component<Props, State> {
         <div className={styles.listName}>
           #{activity.id}: {activity.name}
         </div>
-        <div className={styles.listEndDate}>{dateFormat(activity.end_date, "d. mmm yyyy")}</div>
+        <div className={styles.listEndDate}>{dateFormat(localEndDateTime, "d. mmm yyyy")}</div>
         <div className={styles.editButton} onClick={this.onActivityEditClick.bind(this, activity.id)} />
       </div>
     );

--- a/components/activities/ActivitySheet.tsx
+++ b/components/activities/ActivitySheet.tsx
@@ -26,19 +26,22 @@ class AActivitySheet extends React.Component<Props> {
   render(): React.ReactNode {
     const animationClass = this.props.exiting ? styles.exit : styles.enter;
 
-    const activityExists = this.props.activityId > 0 && !!this.props.activity;
-
     if (this.props.activity) {
+      // Dates are stored in UTC, so we have to pretend we are in a UTC time zone, else display is wrong.
+      const localStartDate = new Date(this.props.activity.start_date);
+      let localStartDateTime = localStartDate.getTime() + localStartDate.getTimezoneOffset() * 60000;
+      const localEndDate = new Date(this.props.activity.end_date);
+      let localEndDateTime = localEndDate.getTime() + localEndDate.getTimezoneOffset() * 60000;
       return (
         <div className={`${styles.root} ${animationClass}`}>
           <div className={styles.nameLabel}>{`#${this.props.activity.id}: ${this.props.activity.name}`}</div>
           <div className={styles.row}>
             <div className={styles.dateLabel}>Start:</div>
-            <div className={styles.dateValue}>{dateFormat(this.props.activity.start_date, "d. mmm yyyy")}</div>
+            <div className={styles.dateValue}>{dateFormat(localStartDateTime, "d. mmm yyyy")}</div>
           </div>
           <div className={styles.row}>
             <div className={styles.dateLabel}>End:</div>
-            <div className={styles.dateValue}>{dateFormat(this.props.activity.end_date, "d. mmm yyyy")}</div>
+            <div className={styles.dateValue}>{dateFormat(localEndDateTime, "d. mmm yyyy")}</div>
           </div>
           <textarea
             className={styles.descriptionTextField}

--- a/components/activities/CreateActivitySubPanel.tsx
+++ b/components/activities/CreateActivitySubPanel.tsx
@@ -86,8 +86,8 @@ class ACreateActivitySubPanel extends React.Component<Props, State> {
           user_id: props.currentUserId,
           name: "",
           description: "",
-          start_date: new Date(),
-          end_date: new Date(),
+          start_date: dateFormat(new Date(), "yyyy-mm-dd"),
+          end_date: dateFormat(new Date(), "yyyy-mm-dd"),
           participants: [],
           resolution_text: "",
         },
@@ -146,17 +146,11 @@ class ACreateActivitySubPanel extends React.Component<Props, State> {
           <div className={styles.label}>Start Date</div>
           <input
             type={"date"}
-            value={dateFormat(
-              // This idiotic timezone math is required because Javascript stores dates in UTC, but
-              // a date picker interprets its `value` in local time.  If you don't add the timezone
-              // offset, the displayed date may be wrong by a day.
-              new Date(this.state.activity.start_date).getTime() + new Date().getTimezoneOffset() * 60000,
-              "yyyy-mm-dd"
-            )}
+            value={this.state.activity.start_date}
             onChange={(e) => {
               const activity: ActivityData = {
                 ...this.state.activity,
-                start_date: e.target.valueAsDate ?? new Date(e.target.value),
+                start_date: e.target.value,
               };
               this.setState({ activity });
             }}
@@ -164,19 +158,11 @@ class ACreateActivitySubPanel extends React.Component<Props, State> {
           <div className={styles.label}>End Date</div>
           <input
             type={"date"}
-            value={dateFormat(
-              // This idiotic timezone math is required because Javascript stores dates in UTC, but
-              // a date picker interprets its `value` in local time.  If you don't add the timezone
-              // offset, the displayed date may be wrong by a day.
-              new Date(this.state.activity.end_date).getTime() + new Date().getTimezoneOffset() * 60000,
-              "yyyy-mm-dd"
-            )}
+            value={this.state.activity.end_date}
             onChange={(e) => {
-              const end_date = e.target.valueAsDate ?? new Date(e.target.value);
-
               const activity: ActivityData = {
                 ...this.state.activity,
-                end_date,
+                end_date: e.target.value,
               };
               this.setState({ activity });
             }}
@@ -369,8 +355,8 @@ class ACreateActivitySubPanel extends React.Component<Props, State> {
         }
         // Would any of those overlap with this new activity?
         return (
-          Math.max(activity.start_date.getTime(), this.state.activity.start_date.getTime()) <=
-          Math.min(activity.end_date.getTime(), this.state.activity.end_date.getTime())
+          Math.max(new Date(activity.start_date).getTime(), new Date(this.state.activity.start_date).getTime()) <=
+          Math.min(new Date(activity.end_date).getTime(), new Date(this.state.activity.end_date).getTime())
         );
       });
       if (this.state.filterStatus === "Busy" && !conflictingActivity) {

--- a/serverAPI.ts
+++ b/serverAPI.ts
@@ -261,8 +261,8 @@ export interface ActivityData {
   user_id: number;
   name: string;
   description: string;
-  start_date: Date;
-  end_date: Date;
+  start_date: string;
+  end_date: string;
   participants: ActivityParticipant[];
   resolution_text: string;
 }
@@ -464,8 +464,6 @@ class AServerAPI {
         activityData.push({
           ...sActivityData,
           participants: ActivityData_StringToParticipants(sActivityData.participants),
-          start_date: new Date(sActivityData.start_date),
-          end_date: new Date(sActivityData.end_date),
         });
       });
 

--- a/serverRequestTypes.ts
+++ b/serverRequestTypes.ts
@@ -238,8 +238,8 @@ export interface RequestBody_CreateActivity {
   user_id: number;
   name: string;
   description: string;
-  start_date: Date;
-  end_date: Date;
+  start_date: string;
+  end_date: string;
   participants: string;
 }
 
@@ -248,8 +248,8 @@ export interface RequestBody_EditActivity {
   user_id: number;
   name: string;
   description: string;
-  start_date: Date;
-  end_date: Date;
+  start_date: string;
+  end_date: string;
   participants: string;
   resolution_text: string;
 }


### PR DESCRIPTION
Switched Activity dates to be stored as strings so there's no UTC conversion in the date pickers.

Did time zone wrangling when displaying dates so that they can display as if we are in the UTC time zone.  Otherwise the displayed date will depend on the time zone of the computer calculating the text string, which may be yours OR the vercel server.